### PR TITLE
Enables react interaction on iOS

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -9,6 +9,10 @@ $body-bg: #ccc;
 
 @import "bootstrap";
 
+// Makes iOS respond to click events
+* {cursor:pointer;}
+
+
 #helpModal.modal.in,
 #helpModal.modal.in + .modal-backdrop.in {
     @media(max-width: $screen-sm-max) {

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -10,8 +10,9 @@ $body-bg: #ccc;
 @import "bootstrap";
 
 // Makes iOS respond to click events
-* {cursor:pointer;}
-
+@media screen and (max-device-width: $screen-sm-max) {
+  * {cursor:pointer;}
+}
 
 #helpModal.modal.in,
 #helpModal.modal.in + .modal-backdrop.in {


### PR DESCRIPTION
- Apparently iOS only lets a user click on anchor tags by default
- Solution found at https://github.com/facebook/react/issues/134
- has been fixed in React 0.14 (apparently).
  Fixes #3 
